### PR TITLE
fixes DateTime in nanoseconds not supported in PHP

### DIFF
--- a/src/Utils/DateDeserializationSubscriber.php
+++ b/src/Utils/DateDeserializationSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ding\DingSDK\Utils;
+
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+
+class DateDeserializationSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            [
+                'event' => 'serializer.pre_deserialize',
+                'method' => 'onPreDeserialize',
+                'format' => 'json',
+            ],
+        ];
+    }
+
+    public function onPreDeserialize(PreDeserializeEvent $event)
+    {
+        $data = $event->getData();
+        $type = $event->getType();
+
+        if ($type['name'] === 'DateTime') {
+            $truncatedDatetime = preg_replace('/(\.\d{6})\d+Z$/', '$1Z', $data);
+            $event->setData($truncatedDatetime);
+        }
+    }
+}

--- a/src/Utils/DateDeserializationSubscriber.php
+++ b/src/Utils/DateDeserializationSubscriber.php
@@ -27,5 +27,9 @@ class DateDeserializationSubscriber implements EventSubscriberInterface
             $truncatedDatetime = preg_replace('/(\.\d{6})\d+Z$/', '$1Z', $data);
             $event->setData($truncatedDatetime);
         }
+
+        if ($data === "0001-01-01T00:00:00Z") {
+            $event->setData("0001-01-01T00:00:00.000000Z");
+        }
     }
 }

--- a/src/Utils/JSON.php
+++ b/src/Utils/JSON.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ding\DingSDK\Utils;
 
+use JMS\Serializer\EventDispatcher\EventDispatcher;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\SerializerBuilder;
 
@@ -20,6 +21,10 @@ class JSON
                 $registry->registerSubscribingHandler(new MixedJSONHandler());
                 $registry->registerSubscribingHandler(new EnumHandler());
             },
-        )->addDefaultHandlers()->build();
+        )->addDefaultHandlers()
+        ->configureListeners(function(EventDispatcher $dispatcher) {
+             $dispatcher->addSubscriber(new DateDeserializationSubscriber());
+        })
+        ->build();
     }
 }


### PR DESCRIPTION
When calling createAuthentication or retry an error occurs as the dates are not formatted properly.
DateTime only goes down to microseconds and formatting with nanoseconds produces an error.